### PR TITLE
Explicitly link with xctest-dynamic-overlay

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,13 +19,17 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/pointfreeco/swift-composable-architecture",
-      .upToNextMajor(from: "1.9.2"))
+      .upToNextMajor(from: "1.9.2")),
+    .package(
+      url: "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      .upToNextMajor(from: "1.0.2")),
   ],
   targets: [
     .target(
       name: "ComposableCoreLocation",
       dependencies: [
-        .product(name: "ComposableArchitecture", package: "swift-composable-architecture")
+        .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay")
       ]
     ),
     .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,9 @@ let package = Package(
       url: "https://github.com/pointfreeco/swift-composable-architecture",
       .upToNextMajor(from: "1.9.2")),
     .package(
+      url: "https://github.com/pointfreeco/swift-concurrency-extras",
+      .upToNextMajor(from: "1.1.0")),
+    .package(
       url: "https://github.com/pointfreeco/xctest-dynamic-overlay",
       .upToNextMajor(from: "1.0.2")),
   ],
@@ -29,7 +32,8 @@ let package = Package(
       name: "ComposableCoreLocation",
       dependencies: [
         .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
-        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay")
+        .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
       ]
     ),
     .testTarget(

--- a/Sources/ComposableCoreLocation/Live.swift
+++ b/Sources/ComposableCoreLocation/Live.swift
@@ -1,5 +1,6 @@
 import Combine
 import ComposableArchitecture
+import ConcurrencyExtras
 import CoreLocation
 
 extension LocationManager {


### PR DESCRIPTION
This prevents a linker error when ComposableCoreLocation is built as a packageproduct framework, as you'd expect to see when multiple modules use it.

ComposableCoreLocation already transitively depends upon xctest-dynamic-overlay, but this makes that more explicit, because ComposableCoreLocation itself actually uses xctest-dynamic-overlay and thus should have an explicit dependency.